### PR TITLE
feature: 드롭다운 UI 구현

### DIFF
--- a/public/icon/DownArrow.svg
+++ b/public/icon/DownArrow.svg
@@ -1,0 +1,10 @@
+<svg width="21" height="17" viewBox="0 0 21 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_219_129)">
+<path d="M15.5859 6.10571L10.4066 10.1762L5.22725 6.10571" stroke="#757575" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_219_129">
+<rect width="16.2817" height="20.7174" fill="white" transform="matrix(0 1 -1 0 20.7656 0)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/common/Dropdown/Dropdown/Dropdown.style.tsx
+++ b/src/components/common/Dropdown/Dropdown/Dropdown.style.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import { size } from '../../../../styles/Theme';
+
+export const DropdownContainer = styled.div`
+  width: ${size.SIZE_019};
+  height: ${size.SIZE_019};
+  display: flex;
+  position: relative;
+  flex-direction: column;
+`;

--- a/src/components/common/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown/Dropdown.tsx
@@ -1,0 +1,21 @@
+import { DropdownList } from '../DropdownList/DropdownList';
+import DropdownItem from '../DropdownItem/DropdownItem';
+import DropdownTrigger from '../DropdownTrigger/DropdownTrigger';
+import { DropdownContainer } from './Dropdown.style';
+
+const BaseDropdown = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <DropdownContainer
+      aria-hidden='true'
+      role='button'
+    >
+      {children}
+    </DropdownContainer>
+  );
+};
+
+export const Dropdown = Object.assign(BaseDropdown, {
+  Trigger: DropdownTrigger,
+  List: DropdownList,
+  Item: DropdownItem,
+});

--- a/src/components/common/Dropdown/DropdownItem/DropdownItem.style.tsx
+++ b/src/components/common/Dropdown/DropdownItem/DropdownItem.style.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import { colors, size } from '../../../../styles/Theme';
+
+export const DropdownItemButton = styled.button`
+  width: 7.5rem;
+  height: ${size.SIZE_012};
+  font-size: ${size.SIZE_009};
+  background-color: ${colors.WHITE};
+  border-radius: ${size.SIZE_003};
+  padding: ${size.SIZE_002};
+  display: flex;
+  border: none;
+  justify-content: center;
+  flex-direction: column;
+
+  &:hover {
+    background-color: ${colors.GRAY_200};
+  }
+`;

--- a/src/components/common/Dropdown/DropdownItem/DropdownItem.tsx
+++ b/src/components/common/Dropdown/DropdownItem/DropdownItem.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+import { DropdownItemButton } from './DropdownItem.style';
+
+interface DropdownItemProps {
+  children: ReactNode;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const DropdownItem = ({ children, onClick }: DropdownItemProps) => {
+  return (
+    <li>
+      <DropdownItemButton
+        onClick={onClick}
+        type='button'
+      >
+        {children}
+      </DropdownItemButton>
+    </li>
+  );
+};
+
+export default DropdownItem;

--- a/src/components/common/Dropdown/DropdownList/DropdownList.style.tsx
+++ b/src/components/common/Dropdown/DropdownList/DropdownList.style.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import { colors, size } from '../../../../styles/Theme';
+
+export const DropdownListUl = styled.ul`
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: ${size.SIZE_003};
+  border-radius: ${size.SIZE_004};
+  border: 1px solid ${colors.GRAY_300};
+  gap: ${size.SIZE_002};
+  width: ${size.SIZE_019};
+  height: 5rem;
+  position: absolute;
+  top: 30%;
+`;

--- a/src/components/common/Dropdown/DropdownList/DropdownList.tsx
+++ b/src/components/common/Dropdown/DropdownList/DropdownList.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+import { DropdownListUl } from './DropdownList.style';
+
+interface DropdownListProps {
+  children: ReactNode;
+}
+
+export const DropdownList = ({ children }: DropdownListProps) => {
+  return <DropdownListUl>{children}</DropdownListUl>;
+};

--- a/src/components/common/Dropdown/DropdownTrigger/DropdownTrigger.style.tsx
+++ b/src/components/common/Dropdown/DropdownTrigger/DropdownTrigger.style.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import { colors, size } from '../../../../styles/Theme';
+
+export const StyledDropDownTrigger = styled.button`
+  width: ${size.SIZE_019};
+  height: 2.25rem;
+  background-color: ${colors.WHITE};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: ${size.SIZE_009};
+  border-radius: ${size.SIZE_004};
+  padding: ${size.SIZE_006};
+  border: 1px solid ${colors.GRAY_300};
+
+  & > svg:active {
+    fill: ${colors.GRAY_200};
+  }
+`;

--- a/src/components/common/Dropdown/DropdownTrigger/DropdownTrigger.tsx
+++ b/src/components/common/Dropdown/DropdownTrigger/DropdownTrigger.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+import { StyledDropDownTrigger } from './DropdownTrigger.style';
+
+interface DropdownTriggerProps {
+  children: ReactNode;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const DropdownTrigger = ({ children, onClick }: DropdownTriggerProps) => {
+  return (
+    <StyledDropDownTrigger
+      type='button'
+      onClick={onClick}
+    >
+      {children}
+    </StyledDropDownTrigger>
+  );
+};
+
+export default DropdownTrigger;

--- a/src/components/main/SortDropdown/SortDropdown.tsx
+++ b/src/components/main/SortDropdown/SortDropdown.tsx
@@ -1,0 +1,23 @@
+import { Dropdown } from '../../common/Dropdown/Dropdown/Dropdown';
+
+const SortDropdown = () => {
+  return (
+    <Dropdown>
+      <Dropdown.Trigger onClick={() => {}}>
+        <span>정렬 기준</span>
+        <img
+          width={24}
+          height={24}
+          src='./icon/DownArrow.svg'
+          alt='아래 화살표'
+        />
+      </Dropdown.Trigger>
+      <Dropdown.List>
+        <Dropdown.Item onClick={() => {}}>조회수 순</Dropdown.Item>
+        <Dropdown.Item onClick={() => {}}>최신 순</Dropdown.Item>
+      </Dropdown.List>
+    </Dropdown>
+  );
+};
+
+export default SortDropdown;

--- a/src/components/main/SortDropdown/SortDropdown.tsx
+++ b/src/components/main/SortDropdown/SortDropdown.tsx
@@ -5,6 +5,7 @@ const SortDropdown = () => {
     <Dropdown>
       <Dropdown.Trigger onClick={() => {}}>
         <span>정렬 기준</span>
+        {/** 이미지 아이콘을 클릭했을 때 180도 회전하도록 추후 구현 */}
         <img
           width={24}
           height={24}

--- a/src/stories/Dropdown/Dropdown.stories.tsx
+++ b/src/stories/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SortDropdown from '../../components/main/SortDropdown/SortDropdown';
+import { Dropdown } from '../../components/common/Dropdown/Dropdown/Dropdown';
+import { action } from '@storybook/addon-actions'; // action 임포트
+
+const meta = {
+  title: 'Dropdown/SortDropdown',
+  component: SortDropdown,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SortDropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: <Dropdown.Trigger onClick={() => action('트리거 클릭')()}>정렬 기준</Dropdown.Trigger>,
+  },
+};

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -2,6 +2,7 @@ export const colors = {
   PRIMARY: '#6EA1F4',
   SECONDARY: '#F1F9FF',
   GRAY_200: '#f5f5f5',
+  GRAY_300: '#d1d5db',
   GREY_400: '#a3a3a3',
   GREY_500: '#737373',
   GREY_600: '#525252',


### PR DESCRIPTION
🛰️ Issue Number
#14 

🪐 작업 내용
드롭다운 UI를 구현하였습니다. active 상태 이전의 hover까지 구현하였습니다.

<img width="1047" alt="Screenshot 2025-02-22 at 1 26 14 AM" src="https://github.com/user-attachments/assets/ca7b34a9-7efd-4d39-b3d1-23df193e86db" />

📚 Reference
**드롭다운 합성 컴포넌트** 자료 참고하였습니다. 
https://so-so.dev/react/make-select/
https://jijiseong.tistory.com/2


✅ Check List

- [X] 코드가 정상적으로 컴파일되나요?
- [X] merge할 브랜치의 위치를 확인했나요?
