### PR TITLE
refactor: 페이지네이션 최대 5개로 변경 #58

### DIFF
--- a/public/icon/prev.svg
+++ b/public/icon/prev.svg
@@ -1,0 +1,10 @@
+<svg width="9" height="15" viewBox="0 0 9 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_609_80)">
+<path d="M7.625 13.75L1.375 7.5L7.625 1.25" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_609_80">
+<rect width="9" height="15" fill="white" transform="matrix(-1 0 0 -1 9 15)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/main/Pagination/Pagination.tsx
+++ b/src/components/main/Pagination/Pagination.tsx
@@ -2,6 +2,8 @@ import PageButton from '../../common/Button/PageButton/PageButton';
 import { PaginationContainer } from './Pagination.style';
 import NextPageButton from '../../common/Button/CircleButton/CircleButton';
 import { colors, size } from '../../../styles/Theme';
+import { useState } from 'react';
+import { PAGE_SIZE } from '../../../constants';
 
 interface PaginationProps {
   color: string;
@@ -11,29 +13,59 @@ interface PaginationProps {
 }
 
 const Pagination = ({ color, onPageClick, currentPageNumber, totalPageNumber }: PaginationProps) => {
+  const [currentPageGroup, setCurrentPageGroup] = useState(0);
+
+  const startPage = currentPageGroup * PAGE_SIZE + 1;
+  const endPage = Math.min(startPage + PAGE_SIZE - 1, totalPageNumber);
+  const hasNextGroup = endPage < totalPageNumber;
+  const hasPrevGroup = startPage > 1;
+
   const handlePageClick = (pageNumber: number) => {
     onPageClick(pageNumber);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
+  const handleNextGroup = () => {
+    if (hasNextGroup) {
+      setCurrentPageGroup((prev) => prev + 1);
+    }
+  };
+
+  const handlePrevGroup = () => {
+    if (hasPrevGroup) {
+      setCurrentPageGroup((prev) => prev - 1);
+    }
+  };
+
   return (
     <PaginationContainer>
-      {Array.from({ length: totalPageNumber }, (_, index) => (
+      {hasPrevGroup && (
+        <NextPageButton
+          color={colors.WHITE}
+          size={size.SIZE_013}
+          iconPath='./icon/prev.svg'
+          iconAlt='이전 페이지 그룹'
+          onClick={handlePrevGroup}
+        />
+      )}
+      {Array.from({ length: endPage - startPage + 1 }, (_, index) => (
         <PageButton
-          key={index}
+          key={startPage + index}
           color={color}
-          onClick={() => handlePageClick(index + 1)}
-          text={`${index + 1}`}
-          isActive={currentPageNumber === index + 1}
+          onClick={() => handlePageClick(startPage + index)}
+          text={`${startPage + index}`}
+          isActive={currentPageNumber === startPage + index}
         />
       ))}
-      <NextPageButton
-        color={colors.WHITE}
-        size={size.SIZE_013}
-        iconPath='./icon/next.svg'
-        iconAlt='다음 페이지 넘어가기 아이콘'
-        onClick={() => {}}
-      />
+      {hasNextGroup && (
+        <NextPageButton
+          color={colors.WHITE}
+          size={size.SIZE_013}
+          iconPath='./icon/next.svg'
+          iconAlt='다음 페이지 그룹'
+          onClick={handleNextGroup}
+        />
+      )}
     </PaginationContainer>
   );
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,6 +4,8 @@ export const COUNTRIES = ['대한민국', '일본'];
 
 export const MIN_VIEW = 10000;
 
+export const PAGE_SIZE = 5;
+
 export const TRAVEL_LABEL = {
   COUNTRY: '여행 국가',
   REGION: '여행 지역',


### PR DESCRIPTION
🛰️ Issue Number
#58 

🪐 작업 내용
- 페이지네이션을 5개의 페이지를 1그룹으로 설정
- 페이지가 5개보다 많을 시 그룹별로 나눔
- 다음 그룹페이지로 넘어갈 경우 이전 그룹으로 가는 버튼 활성화

📚 Reference

✅ Check List

- [X] 코드가 정상적으로 컴파일되나요?
- [X] merge할 브랜치의 위치를 확인했나요?
