### PR TITLE
style: 마커 색 및 크기 변경

### DIFF
--- a/src/components/common/TravelMapMarker/TravelMapMarker.style.tsx
+++ b/src/components/common/TravelMapMarker/TravelMapMarker.style.tsx
@@ -10,12 +10,12 @@ export const MarkerWrapper = styled.div`
 
 export const Circle = styled.div<{ isSelected: boolean }>`
   color: ${colors.WHITE};
-  width: ${size.SIZE_013};
-  height: ${size.SIZE_013};
-  font-size: 15px;
-  background: ${(props) => (props.isSelected ? colors.RED : colors.PRIMARY)};
+  width: ${size.SIZE_014};
+  height: ${size.SIZE_014};
+  font-size: 18px;
+  background: ${(props) => (props.isSelected ? colors.RED : colors.PURPLE)};
   border-radius: 100px;
-  border: 2px solid ${colors.WHITE};
+  border: 3px solid ${colors.WHITE};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -23,6 +23,6 @@ export const Circle = styled.div<{ isSelected: boolean }>`
   transition: 0.3s all;
 
   &:hover {
-    background-color: ${(props) => (props.isSelected ? colors.LIGHT_RED : colors.LIGHT_BLUE)};
+    background-color: ${(props) => (props.isSelected ? colors.LIGHT_RED : colors.LIGHT_PURPLE)};
   }
 `;

--- a/src/components/common/TravelMapMarker/TravelMapMarker.style.tsx
+++ b/src/components/common/TravelMapMarker/TravelMapMarker.style.tsx
@@ -10,9 +10,9 @@ export const MarkerWrapper = styled.div`
 
 export const Circle = styled.div<{ isSelected: boolean }>`
   color: ${colors.WHITE};
-  width: ${size.SIZE_014};
-  height: ${size.SIZE_014};
-  font-size: 18px;
+  width: ${size.SIZE_013_5};
+  height: ${size.SIZE_013_5};
+  font-size: 16px;
   background: ${(props) => (props.isSelected ? colors.RED : colors.PURPLE)};
   border-radius: 100px;
   border: 3px solid ${colors.WHITE};

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -10,6 +10,8 @@ export const colors = {
   GREY_800: '#262626',
   BLACK: '#141619',
   WHITE: '#ffffff',
+  PURPLE: '#947FFE',
+  LIGHT_PURPLE: '#B3A3FF',
   RED: '#FF6174',
   LIGHT_RED: '#FFA1AC',
 };

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -30,6 +30,7 @@ export const size = {
   SIZE_011: '1.5rem',
   SIZE_012: '1.875rem',
   SIZE_013: '2rem',
+  SIZE_013_5: '2.15rem',
   SIZE_014: '2.5rem',
   SIZE_015: '2.75rem',
   SIZE_016: '3.125rem',


### PR DESCRIPTION
🛰️ Issue Number
#116 

🪐 작업 내용
- 지도 마커 크기를 `SIZE_014: '2.5rem'`로 변경 
- 지도 마커 색을 보라색과 연보라로 변경

📚 Reference

✅ Check List

- [X] 코드가 정상적으로 컴파일되나요?
- [X] merge할 브랜치의 위치를 확인했나요?
