### PR TITLE
Refactor: 메인페이지 url을 쿼리 파라미터(url 파라미터) 방식으로 리팩토링

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,15 @@
+have_fun: false
+
+ignore_patterns:
+  - "**/node_modules/**"
+  - "dist/**"
+  - "*.log"
+
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: 10
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,188 @@
+# ddarahang-fe Frontend Code Style Guide
+
+## Introduction
+This style guide defines the coding conventions for the ddarahang-fe frontend project.  
+It is based on the Airbnb JavaScript/React Style Guide, Prettier, and TypeScript best practices, with some project-specific adjustments.  
+The goal is to ensure code readability, maintainability, and consistency across the team.
+
+---
+
+## Key Principles
+
+- **Readability:** Code should be easy to read and understand for all team members.
+- **Consistency:** Consistent style across all files and contributors.
+- **Maintainability:** Code should be easy to modify, extend, and debug.
+- **Automation:** Use of linters and formatters to enforce style automatically.
+
+---
+
+## General Formatting
+
+### Line Length
+- **Maximum line length:** 100–120 characters recommended (Prettier default, not strictly enforced).
+- Break long JSX props, objects, or function arguments onto multiple lines for readability.
+
+### Indentation
+- **2 spaces per indentation level** (no tabs).
+
+### Semicolons
+- **Always use semicolons** at the end of statements.
+
+### Quotes
+- **Single quotes** for strings (`'example'`), including JSX attributes.
+
+### Braces and Spacing
+- Always put a space before opening braces:  
+  `if (condition) { ... }`
+- In JSX, break props onto new lines if there are more than two.
+
+---
+
+## Imports
+
+- **Order:**
+  1. External libraries (e.g., `react`, `react-router-dom`)
+  2. Internal modules (e.g., `src/utils`, `src/components`)
+  3. Styles, images, and other assets
+
+- **Absolute imports** are preferred (from `src/` root).
+- **No file extensions** for `.ts` and `.tsx` imports.
+- **Alphabetical order** within each group is recommended.
+
+Example:
+```tsx
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { colors } from 'src/styles/Theme';
+import MyComponent from 'src/components/MyComponent';
+import logo from 'src/assets/logo.svg';
+```
+
+---
+
+## Naming Conventions
+
+- **Variables, functions, hooks, props:** `camelCase`
+- **Components, classes, types, interfaces:** `PascalCase`
+- **Constants:** `SCREAMING_SNAKE_CASE`
+- **File and folder names:** `camelCase` or `kebab-case` (e.g., `mainHeader`, `main-header`)
+- **Component files:** Always use `.tsx` extension
+
+---
+
+## React & TypeScript
+
+### Functional Components
+- Use **arrow functions** for all components:
+  ```tsx
+  const MyComponent: React.FC<Props> = ({ ... }) => { ... }
+  ```
+
+### Props and State
+- Always define **explicit types** for props and state.
+- Use `interface` or `type` for prop definitions, named in PascalCase.
+
+### TypeScript
+- Avoid using `any` type.
+- Use type inference where possible, but always type public APIs.
+- Name types and interfaces in PascalCase.
+
+---
+
+## Comments
+
+- Write comments to explain **why** something is done, not just **what**.
+- Use complete sentences, starting with a capital letter and proper punctuation.
+- Avoid redundant comments; prefer self-explanatory code.
+
+---
+
+## Styling
+
+- Use **styled-components** or **Emotion** for all component styles.
+- **Do not use inline styles** except for dynamic, one-off cases.
+- Use shared color and size variables from `src/styles/Theme.ts` for consistency.
+- Example:
+  ```tsx
+  import styled from '@emotion/styled';
+  import { colors, size } from 'src/styles/Theme';
+
+  const Wrapper = styled.div`
+    background: ${colors.PRIMARY};
+    padding: ${size.SIZE_009};
+  `;
+  ```
+
+---
+
+## JSX & Formatting
+
+- Use self-closing tags for components without children: `<Component />`
+- Avoid unnecessary curly braces in JSX:  
+  Prefer `<div>text</div>` over `<div>{'text'}</div>`
+- Destructure props in function parameters.
+
+---
+
+## Linting & Formatting Tools
+
+- **ESLint**: Enforces code style and best practices.
+  - Extends Airbnb, React, Prettier, TypeScript, and Storybook recommended rules.
+  - Example rules:
+    - Only allow JSX in `.jsx` and `.tsx` files.
+    - Enforce import order and extension rules.
+    - Disallow unused variables and imports.
+    - Enforce Prettier formatting as errors.
+- **Prettier**: Automatically formats code on save.
+  - Handles indentation, quotes, semicolons, trailing commas, etc.
+
+---
+
+## Example
+
+```tsx
+import React from 'react';
+import styled from '@emotion/styled';
+import { colors, size } from 'src/styles/Theme';
+
+interface ButtonProps {
+  label: string;
+  onClick: () => void;
+}
+
+const StyledButton = styled.button`
+  background: ${colors.PRIMARY};
+  color: ${colors.WHITE};
+  padding: ${size.SIZE_009};
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+`;
+
+const RectangleButton: React.FC<ButtonProps> = ({ label, onClick }) => (
+  <StyledButton onClick={onClick}>
+    {label}
+  </StyledButton>
+);
+
+export default RectangleButton;
+```
+
+---
+
+## Additional Guidelines
+
+- **No console logs** in committed code (except for debugging, which should be removed before merging).
+- **No unused variables or imports**.
+- **No magic numbers**; use named constants where possible.
+- **No direct DOM manipulation**; always use React refs and state.
+- **No inline event handlers** with complex logic; define handler functions outside JSX.
+
+---
+
+## Tooling
+
+- **Formatter:** Prettier (auto-formats code on save)
+- **Linter:** ESLint (checks for style and best practices)
+- **Recommended VSCode Extensions:** ESLint, Prettier

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -7,24 +7,30 @@ import SortDropdown from '../../components/main/SortDropdown/SortDropdown';
 import { colors } from '../../styles/Theme';
 import { StyledMainPageLayout, StyledContentsWrapper } from './MainPage.style';
 import { useSelectOptionContext } from '../../hooks/context/useSelectOptionContext';
-import { SortByType } from '../../types';
+import { CountryType, SortByType } from '../../types';
 import { useSortOptionContext } from '../../hooks/context/useSortOptionContext';
 import Loading from '../../components/common/Loading/Loading';
 import useTravelVideoList from '../../hooks/quries/useGetTravelVideoList';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 const TravelVideoList = lazy(() => import('../../components/main/TravelVideoList/TravelVideoList'));
 
 const MainPage = () => {
-  const savedPageNumber = localStorage.getItem('currentPageNumber');
-  const initialPageNumber = savedPageNumber ? parseInt(savedPageNumber, 10) : 1;
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
 
+  const initialCountryName = (searchParams.get('country') as CountryType) || '';
+  const initialRegionName = searchParams.get('region') || '';
+  const initialSortOption = (searchParams.get('sort') as SortByType) || 'uploadDate';
+  const initialPageNumber = parseInt(searchParams.get('page') || '1', 10);
+
+  const [isInitialized, setIsInitialized] = useState(false);
   const [currentPageNumber, setCurrentPageNumber] = useState<number>(initialPageNumber);
   const { sortOption, setSortOption } = useSortOptionContext();
-
-  const { selectedOption } = useSelectOptionContext();
+  const { selectedOption, setSelectedOption } = useSelectOptionContext();
 
   const { videoListResponse, loading, error, getTravelVideoList } = useTravelVideoList({
-    sortField: 'uploadDate',
+    sortField: sortOption,
     countryName: selectedOption.countryName,
     regionName: selectedOption.selectedOptionLabel,
     pageNumber: currentPageNumber - 1,
@@ -34,51 +40,46 @@ const MainPage = () => {
   const totalPages = videoListResponse?.totalPages ?? 0;
 
   useEffect(() => {
-    localStorage.setItem('currentPageNumber', String(currentPageNumber));
-  }, [currentPageNumber]);
-
-  localStorage.removeItem('sortOption');
-  localStorage.removeItem('uploadDate');
+    setSortOption(initialSortOption);
+    setSelectedOption({
+      countryName: initialCountryName,
+      selectedOptionLabel: initialRegionName,
+      isCountryOption: initialRegionName === '',
+    });
+    setCurrentPageNumber(initialPageNumber);
+    setIsInitialized(true);
+  }, [searchParams]);
 
   useEffect(() => {
-    getTravelVideoList({
-      sortField: 'uploadDate',
-      countryName: selectedOption.countryName,
-      regionName: selectedOption.selectedOptionLabel,
-      pageNumber: currentPageNumber - 1,
-    });
-  }, [selectedOption.countryName, selectedOption.selectedOptionLabel]);
+    if (isInitialized) {
+      const newSearchParams = new URLSearchParams();
+      if (selectedOption.countryName) newSearchParams.set('country', selectedOption.countryName);
+      if (selectedOption.selectedOptionLabel) newSearchParams.set('region', selectedOption.selectedOptionLabel);
+      if (sortOption) newSearchParams.set('sort', sortOption);
+      if (currentPageNumber) newSearchParams.set('page', String(currentPageNumber));
+      navigate(`?${newSearchParams.toString()}`, { replace: true });
+
+      getTravelVideoList({
+        sortField: sortOption,
+        countryName: selectedOption.countryName,
+        regionName: selectedOption.selectedOptionLabel,
+        pageNumber: currentPageNumber - 1,
+      });
+    }
+  }, [isInitialized, currentPageNumber, selectedOption, sortOption]);
 
   const handlePageNumber = (movePageNumber: number) => {
     setCurrentPageNumber(movePageNumber);
-    getTravelVideoList({
-      sortField: sortOption,
-      countryName: selectedOption.countryName,
-      regionName: selectedOption.selectedOptionLabel,
-      pageNumber: movePageNumber - 1,
-    });
   };
 
   const handleSubmitDropdown = (sortBy: SortByType) => {
     setSortOption(sortBy);
     setCurrentPageNumber(1);
-    getTravelVideoList({
-      sortField: sortBy,
-      countryName: selectedOption.countryName,
-      regionName: selectedOption.selectedOptionLabel,
-      pageNumber: currentPageNumber - 1,
-    });
   };
 
   const handleSubmitOption = () => {
     setSortOption('uploadDate');
     setCurrentPageNumber(1);
-    getTravelVideoList({
-      sortField: sortOption,
-      countryName: selectedOption.countryName,
-      regionName: selectedOption.selectedOptionLabel,
-      pageNumber: currentPageNumber - 1,
-    });
   };
 
   return (


### PR DESCRIPTION
🛰️ Issue Number
#143 

🪐 작업 내용
- 메인페이지 url을 쿼리 파라미터(url 파라미터) 방식으로 리팩토링
- 각 선택값(나라, 지역, 페이지, 정렬 기준)에 대한 `initial` 값을 추가.
- `useNavigate`, `useSearchParams` 훅을 사용
- 기존에 `handle~` 메서드 내에서 상태 값 설정하던 부분을 모두 삭제

📚 Reference

✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?

URL 예시 사진
<img width="1440" height="445" alt="Screenshot 2025-07-21 at 15 20 30" src="https://github.com/user-attachments/assets/282cda5e-7b97-4af6-8071-489b78ab9023" />

### 🥝 Comment
아직 프로젝트 전체 구조 파악이 잘 안 되어 헷갈리는 부분이 많았던 것 같습니다. 놓친 부분이 있다면 말씀해주세요!